### PR TITLE
Added test for the spending alert feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
             <scope>test</scope>
         </dependency>
 
+
         <!-- JavaFX -->
         <dependency>
             <groupId>org.openjfx</groupId>

--- a/src/test/java/org/bupt/persosnalfinance/BudgetControllerTest.java
+++ b/src/test/java/org/bupt/persosnalfinance/BudgetControllerTest.java
@@ -1,0 +1,51 @@
+package org.bupt.persosnalfinance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bupt.persosnalfinance.dto.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BudgetControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testCheckOverspending_withRealService() throws Exception {
+
+        double[] lastQuarter = {
+                100.0, 800.0, 150.0, 200.0,
+                120.0, 300.0, 100.0, 180.0,
+                90.0,  60.0,  400.0, 70.0
+        };
+
+        double[] thisQuarter = {
+                130.0, 880.0, 180.0, 220.0,
+                140.0, 350.0, 120.0, 200.0,
+                95.0,  70.0,  420.0, 80.0
+        };
+
+        User user = new User();
+        user.setLastQuarterAvg(lastQuarter);
+        user.setThisQuarter(thisQuarter);
+
+        mockMvc.perform(post("/api/budget/check")
+                        .param("threshold", "0.05") // 5%
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts.length()").value(12))
+                .andExpect(jsonPath("$.alerts[0]").value(org.hamcrest.Matchers.containsString("overspent")));
+    }
+}


### PR DESCRIPTION

Main updates include:
	•	Implemented a Spring Boot integration test using MockMvc to simulate real HTTP requests.
	•	Submitted user spending data covering 12 standard categories (e.g., Food, Rent, Healthcare).
	•	Validated that the system correctly identifies overspending based on a threshold (e.g., 5%).
	•	Asserted that:
	•	The response includes alerts for all categories.
	•	At least one alert contains the keyword “overspent”.

This test ensures that the overspending detection logic is functioning as expected and that the API is returning complete and accurate results.

Please review and merge if everything looks good.